### PR TITLE
Type edits

### DIFF
--- a/lib/typings/types/DBP.ts
+++ b/lib/typings/types/DBP.ts
@@ -1,11 +1,3 @@
-// just fyi, this is not very useful, you can just call "Options" whenever you need them, unless you plan to add more stuff to this this is not needed
-
 import { Options } from 'better-sqlite3';
 
-export type DefaultByteProperties =  {
-    readonly: Options['readonly'] 
-    fileMustExist: Options['fileMustExist']
-    timeout: Options['timeout']
-    verbose: Options['verbose']
-    nativeBinding: Options['nativeBinding']
-}
+export interface DefaultByteProperties extends Options {}


### PR DESCRIPTION
I made DefaultByteProperties extend Options just in case you'll wanna add more properties, if you don't then please just use Options instead of DefaultByteProperties in the places it's needed.